### PR TITLE
davici: Don't limit initially allocated buffer to 32 bytes

### DIFF
--- a/davici.c
+++ b/davici.c
@@ -122,9 +122,9 @@ int davici_connect_unix(const char *path, davici_fdcb fdcb, void *user,
 	return 0;
 }
 
-static unsigned int min(unsigned int a, unsigned int b)
+static unsigned int max(unsigned int a, unsigned int b)
 {
-	return a < b ? a : b;
+	return a > b ? a : b;
 }
 
 static int update_ops(struct davici_conn *c, enum davici_fdops ops)
@@ -540,7 +540,7 @@ static int create_request(enum davici_packet_type type, const char *name,
 	{
 		req->used += strlen(name);
 	}
-	req->allocated = min(32, req->used);
+	req->allocated = max(32, req->used);
 	req->buf = malloc(req->allocated);
 	if (!req->buf)
 	{


### PR DESCRIPTION
If the passed name was longer than 30 bytes (not the case for the currently defined operations) this resulted in a buffer overflow during the `memcpy()` that's based on that original length and not the allocated length.