### PR TITLE
Provide support for TCP/IP connections to the Vici Plugin

### DIFF
--- a/davici.c
+++ b/davici.c
@@ -31,7 +31,8 @@
 /* buffer size for a name tag */
 #define NAME_BUF_LEN (UCHAR_MAX + 1)
 
-enum davici_packet_type {
+enum davici_packet_type
+{
 	DAVICI_CMD_REQUEST = 0,
 	DAVICI_CMD_RESPONSE = 1,
 	DAVICI_CMD_UNKNOWN = 2,
@@ -42,7 +43,8 @@ enum davici_packet_type {
 	DAVICI_EVENT = 7,
 };
 
-struct davici_request {
+struct davici_request
+{
 	struct davici_request *next;
 	unsigned int allocated;
 	unsigned int used;
@@ -53,13 +55,15 @@ struct davici_request {
 	void *user;
 };
 
-struct davici_packet {
+struct davici_packet
+{
 	unsigned int received;
 	char len[sizeof(uint32_t)];
 	char *buf;
 };
 
-struct davici_response {
+struct davici_response
+{
 	struct davici_packet *pkt;
 	unsigned int pos;
 	unsigned int buflen;
@@ -69,14 +73,16 @@ struct davici_response {
 	unsigned int list;
 };
 
-struct davici_event {
+struct davici_event
+{
 	struct davici_event *next;
 	davici_cb cb;
 	void *user;
 	char name[0];
 };
 
-struct davici_conn {
+struct davici_conn
+{
 	int s;
 	struct davici_request *reqs;
 	struct davici_event *events;
@@ -86,17 +92,49 @@ struct davici_conn {
 	enum davici_fdops ops;
 };
 
-static int connect_and_fcntl(int fd, const char *path)
+static void ip_and_port(char *ip_address, char *ip, char *port)
 {
-	struct sockaddr_un addr;
-	int len, flags;
+	const char s[2] = ":";
+	char *token = strtok(ip_address, s);
+	if (token != NULL)
+	{
+		sprintf(ip, "%s", token);
+	}
+
+	while (token != NULL)
+	{
+		token = strtok(NULL, s);
+		if (token != NULL)
+		{
+			sprintf(port, "%s", token);
+		}
+	}
+}
+
+static int connect_in_and_fcntl(int fd, const char *address)
+{
+	struct sockaddr_in addr;
+	int flags;
 
 	memset(&addr, 0, sizeof(addr));
-	addr.sun_family = AF_UNIX;
-	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", path);
-	len = offsetof(struct sockaddr_un, sun_path) + strlen(addr.sun_path);
+	addr.sin_family = AF_INET;
+	char *ip = malloc(strlen(address) + 1);
+	char *ip_address = malloc(strlen(address) + 1);
+	strcpy(ip_address, address);
+	char *port = malloc(6 * sizeof(char));
+	;
+	ip_and_port(ip_address, ip, port);
+	free(ip_address);
+	addr.sin_port = htons(atoi(port));
+	if (inet_pton(AF_INET, ip, &addr.sin_addr) <= 0)
+	{
+		return -1;
+	}
 
-	if (connect(fd, (struct sockaddr*)&addr, len) != 0)
+	free(ip);
+	free(port);
+
+	if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0)
 	{
 		return -errno;
 	}
@@ -112,6 +150,69 @@ static int connect_and_fcntl(int fd, const char *path)
 	{
 		return -errno;
 	}
+	return 0;
+}
+
+static int connect_un_and_fcntl(int fd, const char *path)
+{
+	struct sockaddr_un addr;
+	int len, flags;
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", path);
+	len = offsetof(struct sockaddr_un, sun_path) + strlen(addr.sun_path);
+
+	if (connect(fd, (struct sockaddr *)&addr, len) != 0)
+	{
+		return -errno;
+	}
+	flags = fcntl(fd, F_GETFL);
+	if (flags == -1)
+	{
+		return -errno;
+	}
+#ifdef O_CLOEXEC
+	flags |= O_CLOEXEC;
+#endif
+	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
+	{
+		return -errno;
+	}
+	return 0;
+}
+
+int davici_connect_tcpip(const char *address, davici_fdcb fdcb, void *user,
+						 struct davici_conn **cp)
+{
+	struct davici_conn *c;
+	int err;
+
+	c = calloc(1, sizeof(*c));
+	if (!c)
+	{
+		return -errno;
+	}
+	c->fdcb = fdcb;
+	c->user = user;
+	c->s = socket(AF_INET, SOCK_STREAM, 0);
+
+	if (c->s < 0)
+	{
+		free(c);
+		return -errno;
+	}
+
+	err = connect_in_and_fcntl(c->s, address);
+
+	if (err < 0)
+	{
+		close(c->s);
+		free(c);
+		return err;
+	}
+
+	*cp = c;
 	return 0;
 }
 
@@ -132,11 +233,10 @@ int davici_connect_unix(const char *path, davici_fdcb fdcb, void *user,
 	c->s = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (c->s < 0)
 	{
-		err = -errno;
 		free(c);
-		return err;
+		return -errno;
 	}
-	err = connect_and_fcntl(c->s, path);
+	err = connect_un_and_fcntl(c->s, path);
 	if (err < 0)
 	{
 		close(c->s);
@@ -190,7 +290,7 @@ static int copy_name(char *out, unsigned int outlen,
 	return 0;
 }
 
-static struct davici_request* pop_request(struct davici_conn *c,
+static struct davici_request *pop_request(struct davici_conn *c,
 										  enum davici_packet_type type,
 										  char *name, unsigned int namelen)
 {
@@ -388,18 +488,18 @@ static int handle_message(struct davici_conn *c)
 
 	switch (c->pkt.buf[0])
 	{
-		case DAVICI_CMD_RESPONSE:
-			return handle_cmd_response(c, &pkt);
-		case DAVICI_CMD_UNKNOWN:
-			return handle_cmd_unknown(c);
-		case DAVICI_EVENT_UNKNOWN:
-			return handle_event_unknown(c);
-		case DAVICI_EVENT_CONFIRM:
-			return handle_event_confirm(c);
-		case DAVICI_EVENT:
-			return handle_event(c, &pkt);
-		default:
-			return 0;
+	case DAVICI_CMD_RESPONSE:
+		return handle_cmd_response(c, &pkt);
+	case DAVICI_CMD_UNKNOWN:
+		return handle_cmd_unknown(c);
+	case DAVICI_EVENT_UNKNOWN:
+		return handle_event_unknown(c);
+	case DAVICI_EVENT_CONFIRM:
+		return handle_event_confirm(c);
+	case DAVICI_EVENT:
+		return handle_event(c, &pkt);
+	default:
+		return 0;
 	}
 }
 
@@ -483,7 +583,7 @@ int davici_write(struct davici_conn *c)
 		while (req->sent < sizeof(req->used))
 		{
 			size = htonl(req->used);
-			len = send(c->s, (char*)&size + req->sent,
+			len = send(c->s, (char *)&size + req->sent,
 					   sizeof(size) - req->sent, 0);
 			if (len == -1)
 			{
@@ -585,7 +685,7 @@ int davici_new_cmd(const char *cmd, struct davici_request **rp)
 	return create_request(DAVICI_CMD_REQUEST, cmd, rp);
 }
 
-static void* add_element(struct davici_request *r, enum davici_element type,
+static void *add_element(struct davici_request *r, enum davici_element type,
 						 unsigned int size)
 {
 	unsigned int newlen;
@@ -957,73 +1057,73 @@ int davici_parse(struct davici_response *res)
 	type = res->pkt->buf[res->pos++];
 	switch (type)
 	{
-		case DAVICI_SECTION_START:
-			if (res->list)
-			{
-				return -EBADMSG;
-			}
-			res->section++;
-			err = parse_name(res);
-			if (err < 0)
-			{
-				return err;
-			}
-			return type;
-		case DAVICI_LIST_START:
-			if (res->list)
-			{
-				return -EBADMSG;
-			}
-			err = parse_name(res);
-			if (err < 0)
-			{
-				return err;
-			}
-			res->list++;
-			return type;
-		case DAVICI_LIST_ITEM:
-			if (!res->list)
-			{
-				return -EBADMSG;
-			}
-			err = parse_value(res);
-			if (err < 0)
-			{
-				return err;
-			}
-			return type;
-		case DAVICI_KEY_VALUE:
-			if (res->list)
-			{
-				return -EBADMSG;
-			}
-			err = parse_name(res);
-			if (err < 0)
-			{
-				return err;
-			}
-			err = parse_value(res);
-			if (err < 0)
-			{
-				return err;
-			}
-			return type;
-		case DAVICI_SECTION_END:
-			if (!res->section || res->list)
-			{
-				return -EBADMSG;
-			}
-			res->section--;
-			return type;
-		case DAVICI_LIST_END:
-			if (!res->list)
-			{
-				return -EBADMSG;
-			}
-			res->list--;
-			return type;
-		default:
+	case DAVICI_SECTION_START:
+		if (res->list)
+		{
 			return -EBADMSG;
+		}
+		res->section++;
+		err = parse_name(res);
+		if (err < 0)
+		{
+			return err;
+		}
+		return type;
+	case DAVICI_LIST_START:
+		if (res->list)
+		{
+			return -EBADMSG;
+		}
+		err = parse_name(res);
+		if (err < 0)
+		{
+			return err;
+		}
+		res->list++;
+		return type;
+	case DAVICI_LIST_ITEM:
+		if (!res->list)
+		{
+			return -EBADMSG;
+		}
+		err = parse_value(res);
+		if (err < 0)
+		{
+			return err;
+		}
+		return type;
+	case DAVICI_KEY_VALUE:
+		if (res->list)
+		{
+			return -EBADMSG;
+		}
+		err = parse_name(res);
+		if (err < 0)
+		{
+			return err;
+		}
+		err = parse_value(res);
+		if (err < 0)
+		{
+			return err;
+		}
+		return type;
+	case DAVICI_SECTION_END:
+		if (!res->section || res->list)
+		{
+			return -EBADMSG;
+		}
+		res->section--;
+		return type;
+	case DAVICI_LIST_END:
+		if (!res->list)
+		{
+			return -EBADMSG;
+		}
+		res->list--;
+		return type;
+	default:
+		return -EBADMSG;
 	}
 }
 
@@ -1037,67 +1137,67 @@ int davici_recurse(struct davici_response *res, davici_recursecb section,
 		type = davici_parse(res);
 		switch (type)
 		{
-			case DAVICI_SECTION_START:
-				if (section)
-				{
-					err = section(res, user);
-				}
-				else
-				{
-					err = davici_recurse(res, NULL, NULL, NULL, NULL);
-				}
+		case DAVICI_SECTION_START:
+			if (section)
+			{
+				err = section(res, user);
+			}
+			else
+			{
+				err = davici_recurse(res, NULL, NULL, NULL, NULL);
+			}
+			if (err < 0)
+			{
+				return err;
+			}
+			break;
+		case DAVICI_KEY_VALUE:
+			if (kv)
+			{
+				err = kv(res, user);
 				if (err < 0)
 				{
 					return err;
 				}
-				break;
-			case DAVICI_KEY_VALUE:
-				if (kv)
+			}
+			break;
+		case DAVICI_LIST_START:
+			while (1)
+			{
+				type = davici_parse(res);
+				switch (type)
 				{
-					err = kv(res, user);
-					if (err < 0)
+				case DAVICI_LIST_ITEM:
+					if (li)
 					{
-						return err;
+						err = li(res, user);
+						if (err < 0)
+						{
+							return err;
+						}
 					}
-				}
-				break;
-			case DAVICI_LIST_START:
-				while (1)
-				{
-					type = davici_parse(res);
-					switch (type)
-					{
-						case DAVICI_LIST_ITEM:
-							if (li)
-							{
-								err = li(res, user);
-								if (err < 0)
-								{
-									return err;
-								}
-							}
-							continue;
-						case DAVICI_LIST_END:
-							break;
-						default:
-							if (type < 0)
-							{
-								return type;
-							}
-							return -EBADMSG;
-					}
+					continue;
+				case DAVICI_LIST_END:
 					break;
+				default:
+					if (type < 0)
+					{
+						return type;
+					}
+					return -EBADMSG;
 				}
 				break;
-			case DAVICI_SECTION_END:
-			case DAVICI_END:
-				return 0;
-			default:
-				if (type < 0)
-				{
-					return type;
-				}
-				return -EBADMSG;
+			}
+			break;
+		case DAVICI_SECTION_END:
+		case DAVICI_END:
+			return 0;
+		default:
+			if (type < 0)
+			{
+				return type;
+			}
+			return -EBADMSG;
 		}
 	}
 }
@@ -1111,7 +1211,7 @@ unsigned int davici_get_level(struct davici_response *res)
 	return res->section;
 }
 
-const char* davici_get_name(struct davici_response *res)
+const char *davici_get_name(struct davici_response *res)
 {
 	return res->name;
 }
@@ -1121,7 +1221,7 @@ int davici_name_strcmp(struct davici_response *res, const char *str)
 	return strcmp(res->name, str);
 }
 
-const void* davici_get_value(struct davici_response *res, unsigned int *len)
+const void *davici_get_value(struct davici_response *res, unsigned int *len)
 {
 	*len = res->buflen;
 	return res->buf;
@@ -1212,51 +1312,51 @@ int davici_dump(struct davici_response *res, const char *name, const char *sep,
 		err = davici_parse(res);
 		switch (err)
 		{
-			case DAVICI_END:
-				level--;
-				len = fprintf(out, "%*s}", level * indent, "");
-				if (len < 0)
-				{
-					return -errno;
-				}
-				return total + len;
-			case DAVICI_SECTION_START:
-				len = fprintf(out, "%*s%s {%s", level * indent, "",
-							  res->name, sep);
-				level++;
-				break;
-			case DAVICI_SECTION_END:
-				level--;
-				len = fprintf(out, "%*s}%s", level * indent, "", sep);
-				break;
-			case DAVICI_KEY_VALUE:
-				err = davici_get_value_str(res, buf, sizeof(buf));
-				if (err < 0)
-				{
-					return err;
-				}
-				len = fprintf(out, "%*s%s = %s%s", level * indent, "",
-							  res->name, buf, sep);
-				break;
-			case DAVICI_LIST_START:
-				len = fprintf(out, "%*s%s [%s", level * indent, "",
-							  res->name, sep);
-				level++;
-				break;
-			case DAVICI_LIST_ITEM:
-				err = davici_get_value_str(res, buf, sizeof(buf));
-				if (err < 0)
-				{
-					return err;
-				}
-				len = fprintf(out, "%*s%s%s", level * indent, "", buf, sep);
-				break;
-			case DAVICI_LIST_END:
-				level--;
-				len = fprintf(out, "%*s]%s", level * indent, "", sep);
-				break;
-			default:
+		case DAVICI_END:
+			level--;
+			len = fprintf(out, "%*s}", level * indent, "");
+			if (len < 0)
+			{
+				return -errno;
+			}
+			return total + len;
+		case DAVICI_SECTION_START:
+			len = fprintf(out, "%*s%s {%s", level * indent, "",
+						  res->name, sep);
+			level++;
+			break;
+		case DAVICI_SECTION_END:
+			level--;
+			len = fprintf(out, "%*s}%s", level * indent, "", sep);
+			break;
+		case DAVICI_KEY_VALUE:
+			err = davici_get_value_str(res, buf, sizeof(buf));
+			if (err < 0)
+			{
 				return err;
+			}
+			len = fprintf(out, "%*s%s = %s%s", level * indent, "",
+						  res->name, buf, sep);
+			break;
+		case DAVICI_LIST_START:
+			len = fprintf(out, "%*s%s [%s", level * indent, "",
+						  res->name, sep);
+			level++;
+			break;
+		case DAVICI_LIST_ITEM:
+			err = davici_get_value_str(res, buf, sizeof(buf));
+			if (err < 0)
+			{
+				return err;
+			}
+			len = fprintf(out, "%*s%s%s", level * indent, "", buf, sep);
+			break;
+		case DAVICI_LIST_END:
+			level--;
+			len = fprintf(out, "%*s]%s", level * indent, "", sep);
+			break;
+		default:
+			return err;
 		}
 		if (len < 0)
 		{

--- a/davici.h
+++ b/davici.h
@@ -26,541 +26,566 @@
 #include <stdarg.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/**
- * Opaque connection context.
- */
-struct davici_conn;
+	/**
+	 * Opaque connection context.
+	 */
+	struct davici_conn;
 
-/**
- * Opaque request message context.
- */
-struct davici_request;
+	/**
+	 * Opaque request message context.
+	 */
+	struct davici_request;
 
-/**
- * Opaque response message context.
- */
-struct davici_response;
+	/**
+	 * Opaque response message context.
+	 */
+	struct davici_response;
 
-/**
- * Parsed message element.
- */
-enum davici_element {
-	/** valid end of message */
-	DAVICI_END = 0,
-	/** begin of a section */
-	DAVICI_SECTION_START,
-	/** end of a section */
-	DAVICI_SECTION_END,
-	/** key/value pair */
-	DAVICI_KEY_VALUE,
-	/** begin of a list */
-	DAVICI_LIST_START,
-	/** list item */
-	DAVICI_LIST_ITEM,
-	/** end of a list */
-	DAVICI_LIST_END,
-};
+	/**
+	 * Parsed message element.
+	 */
+	enum davici_element
+	{
+		/** valid end of message */
+		DAVICI_END = 0,
+		/** begin of a section */
+		DAVICI_SECTION_START,
+		/** end of a section */
+		DAVICI_SECTION_END,
+		/** key/value pair */
+		DAVICI_KEY_VALUE,
+		/** begin of a list */
+		DAVICI_LIST_START,
+		/** list item */
+		DAVICI_LIST_ITEM,
+		/** end of a list */
+		DAVICI_LIST_END,
+	};
 
-/**
- * File descriptor watch operations requested.
- */
-enum davici_fdops {
-	/** request read-ready notifications */
-	DAVICI_READ = (1<<0),
-	/** request write-ready notifications */
-	DAVICI_WRITE = (1<<1),
-};
+	/**
+	 * File descriptor watch operations requested.
+	 */
+	enum davici_fdops
+	{
+		/** request read-ready notifications */
+		DAVICI_READ = (1 << 0),
+		/** request write-ready notifications */
+		DAVICI_WRITE = (1 << 1),
+	};
 
-/**
- * Prototype for a command response or event callback function.
- *
- * This kind of callback is invoked for command response and event callbacks.
- * The err parameter indicates any errors in issuing a command or registering
- * for an event.
- *
- * For event registration, also implicitly for streamed command messages using
- * events, the callback gets invoked with a NULL res parameter both after
- * registration and deregistration to indicate any error conditions.
- *
- * Command and event registration responses do not carry a name on the wire,
- * but the name parameter is populated with the name of the issued event
- * registration or command request.
- *
- * @param conn		opaque connection context
- * @param err		0 on success, or a negative receive errno
- * @param name		command or event name raising the callback
- * @param res		event or response message
- * @param user		user context passed to registration function
- */
-typedef void (*davici_cb)(struct davici_conn *conn, int err, const char *name,
-						  struct davici_response *res, void *user);
+	/**
+	 * Prototype for a command response or event callback function.
+	 *
+	 * This kind of callback is invoked for command response and event callbacks.
+	 * The err parameter indicates any errors in issuing a command or registering
+	 * for an event.
+	 *
+	 * For event registration, also implicitly for streamed command messages using
+	 * events, the callback gets invoked with a NULL res parameter both after
+	 * registration and deregistration to indicate any error conditions.
+	 *
+	 * Command and event registration responses do not carry a name on the wire,
+	 * but the name parameter is populated with the name of the issued event
+	 * registration or command request.
+	 *
+	 * @param conn		opaque connection context
+	 * @param err		0 on success, or a negative receive errno
+	 * @param name		command or event name raising the callback
+	 * @param res		event or response message
+	 * @param user		user context passed to registration function
+	 */
+	typedef void (*davici_cb)(struct davici_conn *conn, int err, const char *name,
+							  struct davici_response *res, void *user);
 
-/**
- * Prototype for a file descriptor watch update callback.
- *
- * The watch update callback requests (or updates) a file descriptor watch from
- * the user. The fd parameter is a file descriptor the user shall monitor
- * with select(), poll() or similar functionality. The ops argument is an ORed
- * set of enum davici_fdops flags indicating for what kind of file descriptor
- * events monitoring should be set up.
- *
- * The callback may be invoked from any davici function multiple times, but
- * is guaranteed to get called with a zero ops parameter before returning
- * from davici_disconnect().
- *
- * @param conn		opaque connection context
- * @param fd		file descriptor to watch
- * @param ops		watch operations to register for, enum davici_fdops
- * @param user		user context passed during connection
- * @return			0 if watch updated, or a negative errno
- */
-typedef int (*davici_fdcb)(struct davici_conn *conn, int fd, int ops,
-						   void *user);
+	/**
+	 * Prototype for a file descriptor watch update callback.
+	 *
+	 * The watch update callback requests (or updates) a file descriptor watch from
+	 * the user. The fd parameter is a file descriptor the user shall monitor
+	 * with select(), poll() or similar functionality. The ops argument is an ORed
+	 * set of enum davici_fdops flags indicating for what kind of file descriptor
+	 * events monitoring should be set up.
+	 *
+	 * The callback may be invoked from any davici function multiple times, but
+	 * is guaranteed to get called with a zero ops parameter before returning
+	 * from davici_disconnect().
+	 *
+	 * @param conn		opaque connection context
+	 * @param fd		file descriptor to watch
+	 * @param ops		watch operations to register for, enum davici_fdops
+	 * @param user		user context passed during connection
+	 * @return			0 if watch updated, or a negative errno
+	 */
+	typedef int (*davici_fdcb)(struct davici_conn *conn, int fd, int ops,
+							   void *user);
 
-/**
- * Prototype for a recursive parsing callback.
- *
- * This callback is used by davici_recurse(), a recursive VICI message parser.
- * The same kind of callback is used for section, list item and key/value
- * elements found in a message.
- *
- * If this callback returns a negative errno, parsing is aborted and the
- * same errno is returned from davici_recurse().
- *
- * @param res		response or event message parsing
- * @param user		user context, as passed to davici_recurse()
- * @return			a negative errno on error to stop parsing
- */
-typedef int (*davici_recursecb)(struct davici_response *res, void *user);
+	/**
+	 * Prototype for a recursive parsing callback.
+	 *
+	 * This callback is used by davici_recurse(), a recursive VICI message parser.
+	 * The same kind of callback is used for section, list item and key/value
+	 * elements found in a message.
+	 *
+	 * If this callback returns a negative errno, parsing is aborted and the
+	 * same errno is returned from davici_recurse().
+	 *
+	 * @param res		response or event message parsing
+	 * @param user		user context, as passed to davici_recurse()
+	 * @return			a negative errno on error to stop parsing
+	 */
+	typedef int (*davici_recursecb)(struct davici_response *res, void *user);
 
-/**
- * Create a connection to a VICI Unix socket.
- *
- * Opens a Unix socket connection to a VICI service under path, using a
- * file descriptor monitoring callback function as discussed above.
- *
- * Please note that this function uses connect() on a blocking socket, which
- * in theory is a blocking call.
- *
- * @param path		path to Unix socket
- * @param fdcb		callback to register for file descriptor watching
- * @param user		user context to pass to fdcb
- * @param connp		pointer receiving connection context on success
- * @return			0 on success, or a negative errno
- */
-int davici_connect_unix(const char *path, davici_fdcb fdcb, void *user,
-						struct davici_conn **connp);
+	/**
+	 * Create a connection to a VICI Unix socket.
+	 *
+	 * Opens a Unix socket connection to a VICI service under path, using a
+	 * file descriptor monitoring callback function as discussed above.
+	 *
+	 * Please note that this function uses connect() on a blocking socket, which
+	 * in theory is a blocking call.
+	 *
+	 * @param path		path to Unix socket
+	 * @param fdcb		callback to register for file descriptor watching
+	 * @param user		user context to pass to fdcb
+	 * @param connp		pointer receiving connection context on success
+	 * @return			0 on success, or a negative errno
+	 */
+	int davici_connect_unix(const char *path, davici_fdcb fdcb, void *user,
+							struct davici_conn **connp);
 
-/**
- * Read and process pending connection data.
- *
- * Performs a non-blocking read on the connection, and dispatches any
- * received response or event message. The call uses non-blocking reads
- * only, and returns with a successful result if the call would block. It is
- * usually an unrecoverable error if a negative errno is returned, and the
- * user should call davici_disconnect().
- *
- * @param conn		opaque connection context
- * @return			0 on success, or a negative errno
- */
-int davici_read(struct davici_conn *conn);
+	/**
+	 * Create a connection to a VICI TCP/IP socket.
+	 *
+	 * Opens a TCP/IP socket connection to a VICI service under address, using a
+	 * file descriptor monitoring callback function as discussed above.
+	 *
+	 * Please note that this function uses connect() on a blocking socket, which
+	 * in theory is a blocking call.
+	 *
+	 * Using TCP could pose a security issue. Messages sent to it are not encrypted
+	 * and so this should only be used in a controlled, private network environment
+	 * and not over public networks.
+	 *
+	 * @param address	address (ip:port) to TCP/IP socket
+	 * @param fdcb		callback to register for file descriptor watching
+	 * @param user		user context to pass to fdcb
+	 * @param connp		pointer receiving connection context on success
+	 * @return			0 on success, or a negative errno
+	 */
+	int davici_connect_tcpip(const char *address, davici_fdcb fdcb, void *user,
+							 struct davici_conn **cp);
 
-/**
- * Write queued request data to the connection.
- *
- * Performs a non-blocking write on the connection for any currently queued
- * message. The call uses non-blocking reads only, and returns with a
- * successful result if the call would block. It is usually an unrecoverable
- * error if a negative errno is returned, and the user should call
- * davici_disconnect().
- *
- * @param conn		opaque connection context
- * @return			0 on success, or a negative errno
- */
-int davici_write(struct davici_conn *conn);
+	/**
+	 * Read and process pending connection data.
+	 *
+	 * Performs a non-blocking read on the connection, and dispatches any
+	 * received response or event message. The call uses non-blocking reads
+	 * only, and returns with a successful result if the call would block. It is
+	 * usually an unrecoverable error if a negative errno is returned, and the
+	 * user should call davici_disconnect().
+	 *
+	 * @param conn		opaque connection context
+	 * @return			0 on success, or a negative errno
+	 */
+	int davici_read(struct davici_conn *conn);
 
-/**
- * Close an open VICI connection and free associated resources.
- *
- * Frees any resources associated to a connection, and invokes the file
- * descriptor watch callback of the connection with zero-flags if a monitoring
- * registration is active.
- *
- * Any request messages created with davici_new_cmd() but not queued to
- * the connection using either davici_queue() or davici_queue_streamed()
- * is not freed by this call. Such requests must be freed explicitly by calling
- * davici_cancel() on them.
- *
- * @param conn		opaque connection context
- */
-void davici_disconnect(struct davici_conn *conn);
+	/**
+	 * Write queued request data to the connection.
+	 *
+	 * Performs a non-blocking write on the connection for any currently queued
+	 * message. The call uses non-blocking reads only, and returns with a
+	 * successful result if the call would block. It is usually an unrecoverable
+	 * error if a negative errno is returned, and the user should call
+	 * davici_disconnect().
+	 *
+	 * @param conn		opaque connection context
+	 * @return			0 on success, or a negative errno
+	 */
+	int davici_write(struct davici_conn *conn);
 
-/**
- * Allocate a new request command message.
- *
- * Creates a new but empty request message for a named command. The returned
- * handle must be passed to davici_queue() or davici_queue_streamed() after
- * adding request data. If the connection gets closed before the request
- * could be queued, the request must be freed using davici_cancel().
- *
- * @param cmd		command name
- * @param reqp		receives allocated request context
- * @return			0 on success, or a negative errno
- */
-int davici_new_cmd(const char *cmd, struct davici_request **reqp);
+	/**
+	 * Close an open VICI connection and free associated resources.
+	 *
+	 * Frees any resources associated to a connection, and invokes the file
+	 * descriptor watch callback of the connection with zero-flags if a monitoring
+	 * registration is active.
+	 *
+	 * Any request messages created with davici_new_cmd() but not queued to
+	 * the connection using either davici_queue() or davici_queue_streamed()
+	 * is not freed by this call. Such requests must be freed explicitly by calling
+	 * davici_cancel() on them.
+	 *
+	 * @param conn		opaque connection context
+	 */
+	void davici_disconnect(struct davici_conn *conn);
 
-/**
- * Begin a new section on a request message.
- *
- * Begin a new named section at the current request position. Any started
- * section must have a corresponding davici_section_end() added to form
- * a valid request message. Creating sections within lists is invalid.
- *
- * @param req		request context
- * @param name		name of section to open
- */
-void davici_section_start(struct davici_request *req, const char *name);
+	/**
+	 * Allocate a new request command message.
+	 *
+	 * Creates a new but empty request message for a named command. The returned
+	 * handle must be passed to davici_queue() or davici_queue_streamed() after
+	 * adding request data. If the connection gets closed before the request
+	 * could be queued, the request must be freed using davici_cancel().
+	 *
+	 * @param cmd		command name
+	 * @param reqp		receives allocated request context
+	 * @return			0 on success, or a negative errno
+	 */
+	int davici_new_cmd(const char *cmd, struct davici_request **reqp);
 
-/**
- * End a section previously opened on a request message.
- *
- * Close a section previously started with davici_section_start(). The
- * call must be balanced with davici_section_start() to form a valid request
- * message.
- *
- * @param req		request context
- */
-void davici_section_end(struct davici_request *req);
+	/**
+	 * Begin a new section on a request message.
+	 *
+	 * Begin a new named section at the current request position. Any started
+	 * section must have a corresponding davici_section_end() added to form
+	 * a valid request message. Creating sections within lists is invalid.
+	 *
+	 * @param req		request context
+	 * @param name		name of section to open
+	 */
+	void davici_section_start(struct davici_request *req, const char *name);
 
-/**
- * Add a key/value element to the request message.
- *
- * Adds a new key/value pair at the current request position. Key/values
- * may be added to any explicit or the implicit root section, but not to
- * lists.
- *
- * @param req		request context
- * @param name		key name
- * @param buf		value buffer
- * @param buflen	size, in bytes, of buf
- */
-void davici_kv(struct davici_request *req, const char *name,
-			   const void *buf, unsigned int buflen);
+	/**
+	 * End a section previously opened on a request message.
+	 *
+	 * Close a section previously started with davici_section_start(). The
+	 * call must be balanced with davici_section_start() to form a valid request
+	 * message.
+	 *
+	 * @param req		request context
+	 */
+	void davici_section_end(struct davici_request *req);
 
-/**
- * Add a key with a format string value to the request message.
- *
- * Similar to davici_kv(), but instead of a fixed buffer takes a printf()
- * format string and arguments to form the value of the key/value pair.
- *
- * @param req		request context
- * @param name		key name
- * @param fmt		format string for value
- * @param ...		arguments for fmt string
- */
-void davici_kvf(struct davici_request *req, const char *name,
-				const char *fmt, ...);
+	/**
+	 * Add a key/value element to the request message.
+	 *
+	 * Adds a new key/value pair at the current request position. Key/values
+	 * may be added to any explicit or the implicit root section, but not to
+	 * lists.
+	 *
+	 * @param req		request context
+	 * @param name		key name
+	 * @param buf		value buffer
+	 * @param buflen	size, in bytes, of buf
+	 */
+	void davici_kv(struct davici_request *req, const char *name,
+				   const void *buf, unsigned int buflen);
 
-/**
- * Add a key with a format string value and a va_list to the request message.
- *
- * Very similar to davici_kvf(), but takes a va_list argument list for the
- * format string instead of variable arguments.
- *
- * @param req		request context
- * @param name		key name
- * @param fmt		format string for value
- * @param args		argument list for fmt string
- */
-void davici_vkvf(struct davici_request *req, const char *name,
-				 const char *fmt, va_list args);
+	/**
+	 * Add a key with a format string value to the request message.
+	 *
+	 * Similar to davici_kv(), but instead of a fixed buffer takes a printf()
+	 * format string and arguments to form the value of the key/value pair.
+	 *
+	 * @param req		request context
+	 * @param name		key name
+	 * @param fmt		format string for value
+	 * @param ...		arguments for fmt string
+	 */
+	void davici_kvf(struct davici_request *req, const char *name,
+					const char *fmt, ...);
 
-/**
- * Begin a list of unnamed items in a request message.
- *
- * Starts a new list at the current request message position. Lists may appear
- * in any section, but not in lists. Started lists must be closed by
- * davici_list_end(), and both calls must be balanced to form a valid request
- * message.
- *
- * @param req		request context
- * @param name		list name to open
- */
-void davici_list_start(struct davici_request *req, const char *name);
+	/**
+	 * Add a key with a format string value and a va_list to the request message.
+	 *
+	 * Very similar to davici_kvf(), but takes a va_list argument list for the
+	 * format string instead of variable arguments.
+	 *
+	 * @param req		request context
+	 * @param name		key name
+	 * @param fmt		format string for value
+	 * @param args		argument list for fmt string
+	 */
+	void davici_vkvf(struct davici_request *req, const char *name,
+					 const char *fmt, va_list args);
 
-/**
- * Add a list item value to a previously opened list.
- *
- * List items may be added to lists only, and are invalid in any other context.
- *
- * @param req		request context
- * @param buf		value buffer
- * @param buflen	size, in bytes, of buf
- */
-void davici_list_item(struct davici_request *req, const void *buf,
-					  unsigned int buflen);
+	/**
+	 * Begin a list of unnamed items in a request message.
+	 *
+	 * Starts a new list at the current request message position. Lists may appear
+	 * in any section, but not in lists. Started lists must be closed by
+	 * davici_list_end(), and both calls must be balanced to form a valid request
+	 * message.
+	 *
+	 * @param req		request context
+	 * @param name		list name to open
+	 */
+	void davici_list_start(struct davici_request *req, const char *name);
 
-/**
- * Add a list item with a format string value to a previously opened list.
- *
- * Similar to davici_list_item(), but instead of a fixed buffer takes a
- * printf() format string and variable arguments to form the list item value.
- *
- * @param req		request context
- * @param fmt		format string for value
- * @param ...		arguments for fmt string
- */
-void davici_list_itemf(struct davici_request *req, const char *fmt, ...);
+	/**
+	 * Add a list item value to a previously opened list.
+	 *
+	 * List items may be added to lists only, and are invalid in any other context.
+	 *
+	 * @param req		request context
+	 * @param buf		value buffer
+	 * @param buflen	size, in bytes, of buf
+	 */
+	void davici_list_item(struct davici_request *req, const void *buf,
+						  unsigned int buflen);
 
-/**
- * Add a list item with a format string value and a va_list.
- *
- * Very similar to davici_list_itemf(), but instead of variable arguments
- * takes a va_list for the printf() format string.
- *
- * @param req		request context
- * @param fmt		format string for value
- * @param args		argument list for fmt string
- */
-void davici_list_vitemf(struct davici_request *req, const char *fmt,
-						va_list args);
+	/**
+	 * Add a list item with a format string value to a previously opened list.
+	 *
+	 * Similar to davici_list_item(), but instead of a fixed buffer takes a
+	 * printf() format string and variable arguments to form the list item value.
+	 *
+	 * @param req		request context
+	 * @param fmt		format string for value
+	 * @param ...		arguments for fmt string
+	 */
+	void davici_list_itemf(struct davici_request *req, const char *fmt, ...);
 
-/**
- * End a list previously opened for a request message.
- *
- * Closes the currently open list; valid only in a list context.
- *
- * @param req		request context
- */
-void davici_list_end(struct davici_request *req);
+	/**
+	 * Add a list item with a format string value and a va_list.
+	 *
+	 * Very similar to davici_list_itemf(), but instead of variable arguments
+	 * takes a va_list for the printf() format string.
+	 *
+	 * @param req		request context
+	 * @param fmt		format string for value
+	 * @param args		argument list for fmt string
+	 */
+	void davici_list_vitemf(struct davici_request *req, const char *fmt,
+							va_list args);
 
-/**
- * Clean up a request if it is not passed to davici_queue().
- *
- * Messages get automatically cleaned up when passed to davici_queue() or
- * after it has been fed to callbacks. Use this call only if an allocated
- * message does not get queued(), but the request is aborted.
- *
- * @param req		request context to free
- */
-void davici_cancel(struct davici_request *req);
+	/**
+	 * End a list previously opened for a request message.
+	 *
+	 * Closes the currently open list; valid only in a list context.
+	 *
+	 * @param req		request context
+	 */
+	void davici_list_end(struct davici_request *req);
 
-/**
- * Queue a command request message for submission.
- *
- * The request gets queued, and is sent to the daemon with davici_write()
- * when the daemon accepts new data and all previously queued requests have
- * been processed. Once the daemon responds to the request, davici_read()
- * invokes the passed callback with the response message and the provided
- * user context.
- *
- * @param conn		connection context
- * @param req		request message to queue
- * @param cb		callback to invoke for response message
- * @param user		user context to pass to callback
- * @return			0 on success, or a negative errno
- */
-int davici_queue(struct davici_conn *conn, struct davici_request *req,
-				 davici_cb cb, void *user);
+	/**
+	 * Clean up a request if it is not passed to davici_queue().
+	 *
+	 * Messages get automatically cleaned up when passed to davici_queue() or
+	 * after it has been fed to callbacks. Use this call only if an allocated
+	 * message does not get queued(), but the request is aborted.
+	 *
+	 * @param req		request context to free
+	 */
+	void davici_cancel(struct davici_request *req);
 
-/**
- * Queue a command request using event based streaming.
- *
- * In addition to davici_queue(), this call registers for an event while
- * the command is active and invokes an event callback for each streamed
- * object. Upon completion of the call, it invokes the result callback.
- *
- * @param conn		connection context
- * @param req		request message to queue
- * @param res_cb	callback to invoke for response message
- * @param event		streamed event name to register for
- * @param event_cb	event callback invoked for each streamed event message
- * @param user		user context to pass to callbacks
- * @return			0 on success, or a negative errno
- */
-int davici_queue_streamed(struct davici_conn *conn, struct davici_request *req,
-						  davici_cb res_cb, const char *event,
-						  davici_cb event_cb, void *user);
+	/**
+	 * Queue a command request message for submission.
+	 *
+	 * The request gets queued, and is sent to the daemon with davici_write()
+	 * when the daemon accepts new data and all previously queued requests have
+	 * been processed. Once the daemon responds to the request, davici_read()
+	 * invokes the passed callback with the response message and the provided
+	 * user context.
+	 *
+	 * @param conn		connection context
+	 * @param req		request message to queue
+	 * @param cb		callback to invoke for response message
+	 * @param user		user context to pass to callback
+	 * @return			0 on success, or a negative errno
+	 */
+	int davici_queue(struct davici_conn *conn, struct davici_request *req,
+					 davici_cb cb, void *user);
 
-/**
- * Get the count of all queued davici request messages.
- *
- * @param conn		connection context
- * @return			number of request messages in queue
- */
-unsigned int davici_queue_len(struct davici_conn *conn);
+	/**
+	 * Queue a command request using event based streaming.
+	 *
+	 * In addition to davici_queue(), this call registers for an event while
+	 * the command is active and invokes an event callback for each streamed
+	 * object. Upon completion of the call, it invokes the result callback.
+	 *
+	 * @param conn		connection context
+	 * @param req		request message to queue
+	 * @param res_cb	callback to invoke for response message
+	 * @param event		streamed event name to register for
+	 * @param event_cb	event callback invoked for each streamed event message
+	 * @param user		user context to pass to callbacks
+	 * @return			0 on success, or a negative errno
+	 */
+	int davici_queue_streamed(struct davici_conn *conn, struct davici_request *req,
+							  davici_cb res_cb, const char *event,
+							  davici_cb event_cb, void *user);
 
-/**
- * Register for event messages.
- *
- * Event registration is asynchronous; once registration completed the
- * callback is invoked with a NULL event message. The error code indicates
- * the registration status.
- *
- * @param conn		connection context
- * @param event		event name to register
- * @param cb		callback to invoke on events
- * @param user		user context to pass to cb
- * @return			0 on success, or a negative errno
- */
-int davici_register(struct davici_conn *conn, const char *event,
-					davici_cb cb, void *user);
+	/**
+	 * Get the count of all queued davici request messages.
+	 *
+	 * @param conn		connection context
+	 * @return			number of request messages in queue
+	 */
+	unsigned int davici_queue_len(struct davici_conn *conn);
 
-/**
- * Unregister for event messages.
- *
- * Event deregistration is asynchronous; once deregistration completed the
- * callback is invoked with a NULL event message. The error code indicates
- * the deregistration status.
- *
- * @param conn		connection context
- * @param event		event name to unregister
- * @param cb		callback to invoke on events
- * @param user		user context to pass to cb
- * @return			0 on success, or a negative errno
- */
-int davici_unregister(struct davici_conn *conn, const char *event,
-					  davici_cb cb, void *user);
+	/**
+	 * Register for event messages.
+	 *
+	 * Event registration is asynchronous; once registration completed the
+	 * callback is invoked with a NULL event message. The error code indicates
+	 * the registration status.
+	 *
+	 * @param conn		connection context
+	 * @param event		event name to register
+	 * @param cb		callback to invoke on events
+	 * @param user		user context to pass to cb
+	 * @return			0 on success, or a negative errno
+	 */
+	int davici_register(struct davici_conn *conn, const char *event,
+						davici_cb cb, void *user);
 
-/**
- * Parse a response or event message.
- *
- * davici_parse() implements iterative parsing of response messages by
- * returning enum davici_element types as parsing status. For named types
- * davici_get_name() may be called to get the name of the just parsed element.
- * For types having a value, davici_get_value() returns the value of the
- * just parsed element.
- *
- * If parsing completes with DAVICI_END it may be parsed again using
- * davici_parse(). When davici_parse() returns an error, additional calls
- * to davici_parse() have undefined behavior.
- *
- * @param res		response or event message
- * @return			enum davici_element, or a negative errno
- */
-int davici_parse(struct davici_response *res);
+	/**
+	 * Unregister for event messages.
+	 *
+	 * Event deregistration is asynchronous; once deregistration completed the
+	 * callback is invoked with a NULL event message. The error code indicates
+	 * the deregistration status.
+	 *
+	 * @param conn		connection context
+	 * @param event		event name to unregister
+	 * @param cb		callback to invoke on events
+	 * @param user		user context to pass to cb
+	 * @return			0 on success, or a negative errno
+	 */
+	int davici_unregister(struct davici_conn *conn, const char *event,
+						  davici_cb cb, void *user);
 
-/**
- * Recursive response or event message parser.
- *
- * Using davici_parse(), davici_recurse() parses a VICI message by invoking
- * callbacks for the found elements. Three callbacks can be passed, but all
- * are optional to not further handle an element or descent into a section.
- *
- * If a section callback is given, that callback must invoke davici_recurse()
- * to parse the inner context, or it may return a negative errno. The return
- * value from the recursive davici_recurse() invocation should be returned
- * from the section callback to properly propagate inner errors.
- *
- * For any callback, davici_get_name() or davici_name_strcmp() can be called
- * to get the name of the element for which the callback is called. For lists,
- * the li callback is invoked for items only; davici_get_name() in a list item
- * callback returns the name of the list.
- *
- * davici_get_value() can be used in list item and key/value callbacks to get
- * the value of the element the callback is invoked for.
- *
- * @param res		response or event message
- * @param section	section callback, NULL to skip sub-sections
- * @param li		list item callback, NULL to ignore
- * @param kv		key/value callback, NULL to ignore
- * @return			a negative errno on error
- */
-int davici_recurse(struct davici_response *res, davici_recursecb section,
-				   davici_recursecb li, davici_recursecb kv, void *ctx);
+	/**
+	 * Parse a response or event message.
+	 *
+	 * davici_parse() implements iterative parsing of response messages by
+	 * returning enum davici_element types as parsing status. For named types
+	 * davici_get_name() may be called to get the name of the just parsed element.
+	 * For types having a value, davici_get_value() returns the value of the
+	 * just parsed element.
+	 *
+	 * If parsing completes with DAVICI_END it may be parsed again using
+	 * davici_parse(). When davici_parse() returns an error, additional calls
+	 * to davici_parse() have undefined behavior.
+	 *
+	 * @param res		response or event message
+	 * @return			enum davici_element, or a negative errno
+	 */
+	int davici_parse(struct davici_response *res);
 
-/**
- * Get the section/list nesting level of the current parser position.
- *
- * The root section has a level of 0 and for each nested section the level is
- * incremented by one. When parsing a list, the level is incremented by one.
- * The level after parsing a section/list start is increased just after
- * davici_parse() is called for such an element, while for end elements the
- * level is decreased in davici_parse() for that element.
- *
- * @param res		response or event message
- * @return			section/list nesting level
- */
-unsigned int davici_get_level(struct davici_response *res);
+	/**
+	 * Recursive response or event message parser.
+	 *
+	 * Using davici_parse(), davici_recurse() parses a VICI message by invoking
+	 * callbacks for the found elements. Three callbacks can be passed, but all
+	 * are optional to not further handle an element or descent into a section.
+	 *
+	 * If a section callback is given, that callback must invoke davici_recurse()
+	 * to parse the inner context, or it may return a negative errno. The return
+	 * value from the recursive davici_recurse() invocation should be returned
+	 * from the section callback to properly propagate inner errors.
+	 *
+	 * For any callback, davici_get_name() or davici_name_strcmp() can be called
+	 * to get the name of the element for which the callback is called. For lists,
+	 * the li callback is invoked for items only; davici_get_name() in a list item
+	 * callback returns the name of the list.
+	 *
+	 * davici_get_value() can be used in list item and key/value callbacks to get
+	 * the value of the element the callback is invoked for.
+	 *
+	 * @param res		response or event message
+	 * @param section	section callback, NULL to skip sub-sections
+	 * @param li		list item callback, NULL to ignore
+	 * @param kv		key/value callback, NULL to ignore
+	 * @return			a negative errno on error
+	 */
+	int davici_recurse(struct davici_response *res, davici_recursecb section,
+					   davici_recursecb li, davici_recursecb kv, void *ctx);
 
-/**
- * Get the element name previously parsed in davici_parse().
- *
- * This call has defined behavior only if davici_parse() returned an element,
- * with a name, i.e. a section/list start or a key/value.
- *
- * @param res		response or event message
- * @return			element name
- */
-const char* davici_get_name(struct davici_response *res);
+	/**
+	 * Get the section/list nesting level of the current parser position.
+	 *
+	 * The root section has a level of 0 and for each nested section the level is
+	 * incremented by one. When parsing a list, the level is incremented by one.
+	 * The level after parsing a section/list start is increased just after
+	 * davici_parse() is called for such an element, while for end elements the
+	 * level is decreased in davici_parse() for that element.
+	 *
+	 * @param res		response or event message
+	 * @return			section/list nesting level
+	 */
+	unsigned int davici_get_level(struct davici_response *res);
 
-/**
- * Compare the previously parsed element name against a given string.
- *
- * This call has defined behavior only if davici_parse() returned an element,
- * with a name, i.e. a section/list start or a key/value.
- *
- * @param res		response or event message
- * @param str		string to compare against name
- * @return			strcmp() result
- */
-int davici_name_strcmp(struct davici_response *res, const char *str);
+	/**
+	 * Get the element name previously parsed in davici_parse().
+	 *
+	 * This call has defined behavior only if davici_parse() returned an element,
+	 * with a name, i.e. a section/list start or a key/value.
+	 *
+	 * @param res		response or event message
+	 * @return			element name
+	 */
+	const char *davici_get_name(struct davici_response *res);
 
-/**
- * Get the element value previously parsed in davici_parse().
- *
- * This call has defined behavior only if davici_parse() returned an element,
- * with a value, i.e. a section/list start or a key/value.
- *
- * @param res		response or event message
- * @param len		pointer receiving buffer length
- * @return			buffer containing value
- */
-const void* davici_get_value(struct davici_response *res, unsigned int *len);
+	/**
+	 * Compare the previously parsed element name against a given string.
+	 *
+	 * This call has defined behavior only if davici_parse() returned an element,
+	 * with a name, i.e. a section/list start or a key/value.
+	 *
+	 * @param res		response or event message
+	 * @param str		string to compare against name
+	 * @return			strcmp() result
+	 */
+	int davici_name_strcmp(struct davici_response *res, const char *str);
 
-/**
- * Get the element value if it is a string.
- *
- * This is a convenience function to get the value of an element as string,
- * the same restrictions as to davici_get_value() apply. The function fails
- * if the value has any non-printable characters.
- *
- * @param res		response or event message context
- * @param buf		buffer to write string to
- * @param buflen	size of the buffer
- * @return			number of characters written, or a negative errno
- */
-int davici_get_value_str(struct davici_response *res,
-						 char *buf, unsigned int buflen);
+	/**
+	 * Get the element value previously parsed in davici_parse().
+	 *
+	 * This call has defined behavior only if davici_parse() returned an element,
+	 * with a value, i.e. a section/list start or a key/value.
+	 *
+	 * @param res		response or event message
+	 * @param len		pointer receiving buffer length
+	 * @return			buffer containing value
+	 */
+	const void *davici_get_value(struct davici_response *res, unsigned int *len);
 
-/**
- * Convert value using a format specifier.
- *
- * This functions handles the value like a string, and then uses a scanf()
- * format string to convert the value to the passed argument pointers.
- *
- * @param res		response or event message context
- * @param fmt		scanf() format string
- * @param ...		arguments of format string
- * @return			number of input items matched, or a negative errno
- */
-int davici_value_scanf(struct davici_response *res, const char *fmt, ...);
+	/**
+	 * Get the element value if it is a string.
+	 *
+	 * This is a convenience function to get the value of an element as string,
+	 * the same restrictions as to davici_get_value() apply. The function fails
+	 * if the value has any non-printable characters.
+	 *
+	 * @param res		response or event message context
+	 * @param buf		buffer to write string to
+	 * @param buflen	size of the buffer
+	 * @return			number of characters written, or a negative errno
+	 */
+	int davici_get_value_str(struct davici_response *res,
+							 char *buf, unsigned int buflen);
 
-/**
- * Convert value using a format specifier, va_list variant.
- *
- * Like davici_value_scanf(), but takes arguments in a va_list.
- *
- * @param res		response or event message context
- * @param fmt		scanf() format string
- * @param args		arguments of format string
- * @return			number of input items matched, or a negative errno
- */
-int davici_value_vscanf(struct davici_response *res, const char *fmt,
-						va_list args);
+	/**
+	 * Convert value using a format specifier.
+	 *
+	 * This functions handles the value like a string, and then uses a scanf()
+	 * format string to convert the value to the passed argument pointers.
+	 *
+	 * @param res		response or event message context
+	 * @param fmt		scanf() format string
+	 * @param ...		arguments of format string
+	 * @return			number of input items matched, or a negative errno
+	 */
+	int davici_value_scanf(struct davici_response *res, const char *fmt, ...);
+
+	/**
+	 * Convert value using a format specifier, va_list variant.
+	 *
+	 * Like davici_value_scanf(), but takes arguments in a va_list.
+	 *
+	 * @param res		response or event message context
+	 * @param fmt		scanf() format string
+	 * @param args		arguments of format string
+	 * @return			number of input items matched, or a negative errno
+	 */
+	int davici_value_vscanf(struct davici_response *res, const char *fmt,
+							va_list args);
 
 /**
  * Convert value using a format specifier, error checking variant.
@@ -576,43 +601,43 @@ int davici_value_vscanf(struct davici_response *res, const char *fmt,
  * @param ...		arguments of format string
  * @return			a negative errno on error
  */
-#define davici_value_escanf(res, fmt, ...) ({\
-	unsigned int _v; \
-	int _m, _e, _c; \
-	_e = sizeof((void*[]){ __VA_ARGS__ }) / sizeof(void*); \
+#define davici_value_escanf(res, fmt, ...) ({                 \
+	unsigned int _v;                                          \
+	int _m, _e, _c;                                           \
+	_e = sizeof((void *[]){__VA_ARGS__}) / sizeof(void *);    \
 	_m = davici_value_scanf(res, fmt "%n", __VA_ARGS__, &_c); \
-	davici_get_value(res, &_v); \
-	(_m == _e && _c == _v) ? 0 : -EBADMSG; \
+	davici_get_value(res, &_v);                               \
+	(_m == _e && _c == _v) ? 0 : -EBADMSG;                    \
 })
 
-/**
- * Compare the element value to a given string.
- *
- * This is a convenience function to compare the value of an element as string
- * to a given string. The same restrictions as to davici_get_value() apply.
- *
- * @param res		response or event message
- * @param str		string to compare against value
- * @return			strcmp() result
- */
-int davici_value_strcmp(struct davici_response *res, const char *str);
+	/**
+	 * Compare the element value to a given string.
+	 *
+	 * This is a convenience function to compare the value of an element as string
+	 * to a given string. The same restrictions as to davici_get_value() apply.
+	 *
+	 * @param res		response or event message
+	 * @param str		string to compare against value
+	 * @return			strcmp() result
+	 */
+	int davici_value_strcmp(struct davici_response *res, const char *str);
 
-/**
- * Dump a response or event message to a FILE stream.
- *
- * The dump output is not considered stable, but solely for debugging
- * purposes.
- *
- * @param res		response or event message context
- * @param name		name of the message to dump
- * @param sep		value separator, such as "\n"
- * @param level		base indentation level
- * @param indent	number of spaces to use for indentation
- * @param out		FILE stream to write to
- * @return			total bytes written, or a negative errno on error
- */
-int davici_dump(struct davici_response *res, const char *name, const char *sep,
-				unsigned int level, unsigned int indent, FILE *out);
+	/**
+	 * Dump a response or event message to a FILE stream.
+	 *
+	 * The dump output is not considered stable, but solely for debugging
+	 * purposes.
+	 *
+	 * @param res		response or event message context
+	 * @param name		name of the message to dump
+	 * @param sep		value separator, such as "\n"
+	 * @param level		base indentation level
+	 * @param indent	number of spaces to use for indentation
+	 * @param out		FILE stream to write to
+	 * @return			total bytes written, or a negative errno on error
+	 */
+	int davici_dump(struct davici_response *res, const char *name, const char *sep,
+					unsigned int level, unsigned int indent, FILE *out);
 
 #ifdef __cplusplus
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -18,9 +18,11 @@ TESTS = \
 	many.tst \
 	event.tst \
 	stream.tst \
+	tcpsock.tst \
 	recurse.tst \
 	badsock.tst \
 	cmdunknown.tst \
+	badtcpsock.tst \
 	eventunknown.tst
 
 cmd_tst_SOURCES = cmd.c
@@ -30,6 +32,8 @@ event_tst_SOURCES = event.c
 stream_tst_SOURCES = stream.c
 recurse_tst_SOURCES = recurse.c
 badsock_tst_SOURCES = badsock.c
+badtcpsock_tst_SOURCES = badtcpsock.c
+tcpsock_tst_SOURCES = tcpsock.c
 cmdunknown_tst_SOURCES = cmdunknown.c
 eventunknown_tst_SOURCES = eventunknown.c
 

--- a/tests/badtcpsock.c
+++ b/tests/badtcpsock.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 onway ag
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#include "tester.h"
+
+#include <assert.h>
+#include <errno.h>
+
+int iocb(struct davici_conn *c, int fd, int ops, void *user)
+{
+	assert(0);
+}
+
+int main(int argc, char *argv[])
+{
+	struct davici_conn *c;
+	int ret;
+
+	ret = davici_connect_tcpip("127.0.0.1:66600", iocb, NULL, &c);
+	assert(ret != 0);
+	return 0;
+}

--- a/tests/tcpsock.c
+++ b/tests/tcpsock.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 onway ag
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#include "tester.h"
+
+#include <assert.h>
+#include <errno.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <unistd.h>
+
+void *mock_server(void *add_port)
+{
+    unsigned int port = (__UINTPTR_TYPE__)add_port;
+    int server_fd;
+    struct sockaddr_in address;
+    server_fd = socket(AF_INET, SOCK_STREAM, 0);
+    assert(server_fd >= 0);
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = INADDR_ANY;
+    address.sin_port = htons(port);
+    assert(bind(server_fd, (struct sockaddr *)&address, sizeof(address)) >= 0);
+    assert(listen(server_fd, 3) >= 0);
+    sleep(1);
+    return (void *)(__intptr_t)close(server_fd);
+}
+
+int iocb(struct davici_conn *c, int fd, int ops, void *user)
+{
+    assert(0);
+}
+
+int main(int argc, char *argv[])
+{
+    struct davici_conn *c;
+    pthread_t thread_id;
+    void *port = (void *)55555;
+    pthread_create(&thread_id, NULL, mock_server, port);
+
+    int ret = davici_connect_tcpip("127.0.0.1:55555", iocb, NULL, &c);
+
+    pthread_join(thread_id, NULL);
+    assert(ret == 0);
+    return 0;
+}


### PR DESCRIPTION
Currently only connections via a unix socket to the vici plugin are supported by davici. It would be useful to allow connections via TCP/IP so that Strongswan can be deployed as a virtual network function, container or other virtualised resource inside private networks and be controlled via the davici/vici interface outside of the localised network of the virtual resource.

This PR adds a new function, `davici_connect_tcpip`, to provide this capability.